### PR TITLE
Implement workflow logic and add Jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.js",
   "scripts": {
     "start": "wrangler dev",
-    "deploy": "wrangler publish"
+    "deploy": "wrangler publish",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "author": "AIVELLE",
   "license": "MIT",
@@ -15,6 +16,8 @@
     "dotenv": "^16.3.1"
   },
   "devDependencies": {
-    "wrangler": "^3.45.0"
-  }
+    "wrangler": "^3.45.0",
+    "jest": "^29.6.4"
+  },
+  "type": "module"
 }

--- a/src/workflows/Create/attach_image_to_any_post.js
+++ b/src/workflows/Create/attach_image_to_any_post.js
@@ -2,9 +2,35 @@ export default async function attachImageToAnyPost(input) {
   // input: { imageUrl, postId, platform, etc. }
   console.log("🖼️ Attach Image triggered with input:", input);
 
-  // TODO: Add logic to attach image to a social post
+  const { imageUrl, pageId, notionToken } = input;
+
+  const response = await fetch(`https://api.notion.com/v1/pages/${pageId}`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${notionToken}`,
+      "Notion-Version": "2022-06-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      properties: {
+        Attachment: {
+          files: [
+            {
+              type: "external",
+              name: imageUrl.split("/").pop(),
+              external: { url: imageUrl },
+            },
+          ],
+        },
+      },
+    }),
+  });
+
+  const data = await response.json();
+
   return {
     status: "success",
-    message: "Image attached to post (mock)."
+    message: "Image attached to post",
+    notion: data,
   };
 }

--- a/src/workflows/Create/content_repurpose.js
+++ b/src/workflows/Create/content_repurpose.js
@@ -2,9 +2,31 @@ export default async function repurposeContent(input) {
   // input: { originalContent, targetFormat, platform }
   console.log("♻️ Repurpose Content triggered with input:", input);
 
-  // TODO: Add content rewriting logic (e.g., convert blog → LinkedIn post)
+  const { originalContent, targetFormat, openaiApiKey } = input;
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${openaiApiKey}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-3.5-turbo",
+      messages: [
+        {
+          role: "system",
+          content: `Rewrite the following content for ${targetFormat}`,
+        },
+        { role: "user", content: originalContent },
+      ],
+    }),
+  });
+
+  const data = await response.json();
+  const rewritten = data.choices?.[0]?.message?.content?.trim() || "";
+
   return {
     status: "success",
-    message: "Content repurposed (mock)."
+    message: rewritten,
   };
 }

--- a/src/workflows/Create/reschedule_meeting.js
+++ b/src/workflows/Create/reschedule_meeting.js
@@ -2,10 +2,62 @@ export default async function rescheduleMeeting(input) {
   // input: { meetingId, newDate, newTime, participants, etc. }
   console.log("📆 Reschedule Meeting triggered with input:", input);
 
-  // TODO: Add logic to check availability, update meeting time, notify participants
+  const {
+    googleToken,
+    calendarId,
+    eventId,
+    newDate,
+    newTime,
+    newEndTime,
+  } = input;
+
+  const startDateTime = `${newDate}T${newTime}`;
+  const endDateTime = newEndTime || `${newDate}T23:59:00Z`;
+
+  const freebusyRes = await fetch(
+    "https://www.googleapis.com/calendar/v3/freeBusy",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${googleToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        timeMin: startDateTime,
+        timeMax: endDateTime,
+        items: [{ id: calendarId }],
+      }),
+    }
+  );
+  const busyData = await freebusyRes.json();
+  if (busyData.calendars?.[calendarId]?.busy?.length) {
+    return {
+      status: "failed",
+      message: "Time slot is busy",
+      busy: busyData.calendars[calendarId].busy,
+    };
+  }
+
+  const patchRes = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events/${eventId}`,
+    {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${googleToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        start: { dateTime: startDateTime },
+        end: { dateTime: endDateTime },
+      }),
+    }
+  );
+  const eventData = await patchRes.json();
+
   return {
     status: "success",
-    message: "Meeting rescheduled (mock)."
+    message: "Meeting rescheduled",
+    event: eventData,
   };
 }
 

--- a/src/workflows/automation/auto_reply.js
+++ b/src/workflows/automation/auto_reply.js
@@ -4,9 +4,32 @@
  * @example "Auto-reply to all emails with 'Thank you for your message'"
  */
 export async function run({ prompt, context }) {
-  // TODO: Implement auto-reply logic
-  return {
-    message: "Auto-reply sent (mock)",
+  const { gmailToken, replyTo, subject, threadId } = context;
+
+  const email = [
+    `To: ${replyTo}`,
+    `Subject: Re: ${subject}`,
+    "",
     prompt,
+  ].join("\r\n");
+
+  const encoded = Buffer.from(email).toString("base64url");
+
+  await fetch(
+    "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${gmailToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ raw: encoded, threadId }),
+    }
+  );
+
+  return {
+    message: "Auto-reply sent",
+    prompt,
+    to: replyTo,
   };
-} 
+}

--- a/src/workflows/automation/auto_tagging.js
+++ b/src/workflows/automation/auto_tagging.js
@@ -4,9 +4,30 @@
  * @example "Automatically tag all new notes with #meeting"
  */
 export async function run({ prompt, context }) {
-  // TODO: Implement auto-tagging logic
+  const { notionToken, pageId, tags = [] } = context;
+
+  const response = await fetch(`https://api.notion.com/v1/pages/${pageId}`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${notionToken}`,
+      "Notion-Version": "2022-06-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      properties: {
+        Tags: {
+          multi_select: tags.map((t) => ({ name: t })),
+        },
+      },
+    }),
+  });
+
+  const data = await response.json();
+
   return {
-    message: "Auto-tagging completed (mock)",
+    message: "Auto-tagging completed",
     prompt,
+    pageId,
+    notion: data,
   };
-} 
+}

--- a/tests/workflows.test.js
+++ b/tests/workflows.test.js
@@ -1,0 +1,82 @@
+import { jest } from '@jest/globals';
+import { run as autoReply } from '../src/workflows/automation/auto_reply.js';
+import { run as autoTagging } from '../src/workflows/automation/auto_tagging.js';
+import attachImage from '../src/workflows/Create/attach_image_to_any_post.js';
+import repurposeContent from '../src/workflows/Create/content_repurpose.js';
+import rescheduleMeeting from '../src/workflows/Create/reschedule_meeting.js';
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  );
+});
+
+describe('Workflow automation functions', () => {
+  test('auto_reply returns confirmation', async () => {
+    const result = await autoReply({
+      prompt: 'Thank you',
+      context: {
+        gmailToken: 'token',
+        replyTo: 'a@example.com',
+        subject: 'Hello',
+        threadId: '1',
+      },
+    });
+    expect(result.message).toBe('Auto-reply sent');
+  });
+
+  test('auto_tagging returns confirmation', async () => {
+    const result = await autoTagging({
+      prompt: 'tag',
+      context: { notionToken: 'token', pageId: 'page', tags: ['t1'] },
+    });
+    expect(result.message).toBe('Auto-tagging completed');
+  });
+});
+
+describe('Create workflows', () => {
+  test('attach_image_to_any_post returns success', async () => {
+    const result = await attachImage({
+      pageId: 'page',
+      notionToken: 'token',
+      imageUrl: 'http://example.com/img.png',
+    });
+    expect(result.status).toBe('success');
+  });
+
+  test('content_repurpose returns success', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({ choices: [{ message: { content: 'done' } }] }),
+    });
+    const result = await repurposeContent({
+      originalContent: 'text',
+      targetFormat: 'LinkedIn',
+      openaiApiKey: 'key',
+    });
+    expect(result.status).toBe('success');
+    expect(result.message).toBe('done');
+  });
+
+  test('reschedule_meeting returns success', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ calendars: { cal: { busy: [] } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: 'event' }),
+      });
+    const result = await rescheduleMeeting({
+      googleToken: 'token',
+      calendarId: 'cal',
+      eventId: 'event',
+      newDate: '2024-01-01',
+      newTime: '10:00:00Z',
+      newEndTime: '11:00:00Z',
+    });
+    expect(result.status).toBe('success');
+  });
+});


### PR DESCRIPTION
## Summary
- flesh out automation and creation workflow logic using external APIs
- add Jest tests covering updated workflows
- enable ESM Jest testing and update scripts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852db1010688326b662867d0e109ae7